### PR TITLE
Integrated quick-fedora-mirror.

### DIFF
--- a/Mirrors-AutoSync.conf
+++ b/Mirrors-AutoSync.conf
@@ -56,16 +56,17 @@
 			]
 		},
 		{
-			"name" : "epel",
+			"name" : "fedora",
 			"schedule" : {
 				"hour" : "3,9,15,21",
 				"minute": 15,
 				"second": 0
 			},
-			"exec" : "rsync.py",
+			"exec" : "fedora.py",
 			"argument" : [
 				"rsync://dl.fedoraproject.org/fedora-epel/",
-				"/mirrors/epel"
+				"/mirrors/fedora",
+				"/metadata/quick-fedora-mirror.timefile"
 			]
 		},
 		{

--- a/mirrorsimage/Dockerfile
+++ b/mirrorsimage/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
 
 MAINTAINER zxt @ Geek Pie Association
-RUN apk add --no-cache git python3 rsync && pip3 install apscheduler bandersnatch
+RUN apk add --no-cache git python3 rsync zsh && pip3 install apscheduler bandersnatch
 

--- a/quick-fedora-mirror.conf
+++ b/quick-fedora-mirror.conf
@@ -1,0 +1,175 @@
+# Configuration file for quick-fedora-mirror
+# This file is sourced by the shell and must be in valid sh syntax.
+
+# Maintaince note: DESTD and TIMEFILE is essentially ignored because they are specified by command line arguments in fedora.py
+
+#### Required settings
+# Required: The the directory holding your copy of all of the modules you
+# **Ignored** if --destination-dir is specified.
+# mirror.  Does not include any module name
+DESTD=/mirrors/fedora
+
+# Required: The file in which to store the last mirror time.
+# **Ignored** if --timefile is specified.
+# Note: this really should not be in the repository itself.
+TIMEFILE=/metadata/quick-fedora-mirror.timefile
+
+# Other settings
+# The remote host to rsync from, not including a module name
+REMOTE=rsync://mirrors.kernel.org/fedora
+
+# The master module, which holds the other modules
+# MASTERMODULE=fedora-buffet
+
+# Tier 1 Fedora mirrors should uncomment the following to get the proper
+# pre-bitflip content.
+# MASTERMODULE=fedora-buffet0
+# PREBITFLIP=1
+
+# Define if the entire repository (all modules under fedora-buffet) should be
+# mirrored.  If set, MODULES (below) is ignored
+# MIRRORBUFFET=
+
+# An array containing the modules to be mirrored
+MODULES=(fedora-enchilada fedora-epel)
+
+# The name of the file holding the file list on the mirror host Note: the
+# string '$mdir' will be replaced with the name of the current module directory
+# in context, and so the '$' must be escaped or the string quoted.
+# FILELIST='fullfiletimelist-$mdir'
+
+# An array of extra file lists to be transferred.  They won't be processed, but
+# will implicitly be included in every transfer because file lists can't be
+# included in the file lists.  '$mdir' is substituted as above.
+# Note that if you change this, you will want to do a run with -a to pick up
+# those extra files even in unchanged modules.
+# EXTRAFILES=(fullfilelist imagelist-\$mdir)
+
+# Mapping of MODULES to directory names, as an associative array
+# MODULEMAPPING=(fedora-alt alt  fedora-archive archive
+#                fedora-enchilada fedora  fedora-epel epel)
+
+# rsync binary
+# RSYNC=/usr/bin/rsync
+
+# curl binary (only if MirrorManager checkins are enabled; see below).
+# CURL=/usr/bin/curl
+
+# Array of default options to pass to rsync
+# Will be modified automatically according to VERBOSITY level; no need to set
+# -q, -v or --info here.
+# You can add excludes here, but the script will always detect those files as
+# missing and will add them back to the file list.  This may generate
+# complaints from rsync, but should not cause any problems.
+# Note that some of these options may be required for proper operation of the
+# script.
+# RSYNCOPTS=(-aSH -f 'R .~tmp~' --stats --preallocate --delay-updates --out-format='@ %i  %n%L')
+
+# By default quick-fedora-mirror will try to detect and recover from an aborted
+# rsync run by moving any already downloaded files into place before
+# processing,  Define NORSYNCRECOVERY (to anything) to prevent this.
+# NORSYNCRECOVERY=
+
+# Define KEEPDIRTIMES (to anything) to make a third rsync call which restores
+# the timestamps of any directories which were modified after file removal.
+# This won't ensure that timestamps are always up to date, but its good enough
+# if you don't modify your repository locally.  Maintaining directory
+# timestamps isn't important for mirroring in any case.
+# KEEPDIRTIMES=
+
+# DEFINE CHECKIN_SITE and CHECKIN_PASSWORD to perform a mirrormanager checkin
+# at the completion of the run if rsync succeeded without error.
+# CHECKIN_HOST will default to the output of the hostname command.   Set it if necessary.
+# This requires that "curl" be installed; see CURL above if it's not in /usr/bin.
+# CHECKIN_SITE=
+# CHECKIN_PASSWORD=
+# CHECKIN_HOST=
+
+# If you have configured multiple mirrormanager hostnames to and virtually
+# spread the modules/categories you mirror between them, then you can configure
+# per-module checkin hosts as follows.  If you don't, then the CHECKIN_HOST you
+# set above, or the default, will apply.  Note that the module name is used,
+# not the mirrormanager category, and that '-' in the module name is replaced
+# by '_' to make a legal variable name.
+# CHECKIN_HOST_fedora_archive
+# CHECKIN_HOST_fedora_alt
+
+# Verbosity levels - info sent to stdout; usually this gets mailed to root when
+# being run by cron
+# 0 - quiet
+# 1 - quiet if no changes, otherwise basic transfer info
+# 2 - no -q to rsync
+# 3 - very slightly more verbosity
+# 4 - One -v to rsync
+# 5 - Another -v to rsync
+# 6 - Output of all settings
+# 7 - Add --progress to rsync
+# 8 - Shell script trace
+VERBOSE=4
+
+# Define (to anything) to enable logging to the systemd journal (via
+# systemd-cat).  the identifier "quick-fedora-mirror" is used, so logs can be
+# retrieved with: journalctl -t quick-fedora-mirror
+# LOGJOURNAL=
+
+# Define to a full path to enable logging to that file.
+# The provided file must already exist and be writable.
+# Is only considered if LOGJOURNAL above is not defined.
+# LOGFILE=
+
+# Logging fields - Each character selects a piece of information to log.
+# @ - Absolutely everything.
+# a - aborted run recovery
+# A - each recovered file from an aborted run
+# c - rsync calls
+# C - rsync call completions
+# d - File/directory deletion start/end
+# D - all file/directory deletes
+# e - minor errors
+# E - serious errors
+# F - all transferred files (not impl)
+# g - file list generation start/end
+# k - lock contention
+# l - per-module local file list generation (recursive find) start/end
+# m - mirrormanager checkin
+# M - mirrormanager checkin detail
+# n - lack of updates in a run
+# N - lack of updates in a module
+# o - remote file list download start/end
+# p - module processing start/end
+# p - per-module module processing start/end
+# r - run start
+# R - run end
+# s - Basic transfer statistics
+# S - Detailed transfer statistics
+# t - directory time updates (not impl)
+# LOGITEMS=aeElrRs
+
+# When q-f-m fails to run becuse it is already running, it checks the time
+# since the last successful run.  If that is larger than this value, it logs a
+# serious error.  Thid helps to detect a hung run or issues with slow
+# transfers.
+# WARNDELAY=$((60 * 60 * 24)) # One day
+
+# When q-f-m encounters an error calling rsync, it may (depending on the error)
+# sleep and retry.  It will always sleep with exponential backup.  Set
+# MAXRETRIES to limit the number of times it retries.
+# MAXRETRIES=10
+
+# mktemp will be called after this file is sourced to make a temporary
+# directory.  This directory can contain a large amount of data, and that data
+# is specified by the server.  If your /tmp is small and you are concerned
+# about the server potentially sending extra-huge files and filling things up,
+# you can set TMPDIR here.
+# TMPDIR=
+
+# A regular expression used to filter the file lists. It must be quoted (or
+# very carefully escaped). Entries matching this expression will not be synced
+# and are expected not to be present locally. They will also be ignored by
+# quick-fedora-hardlink. Cannot contain commas. Run against the file list that
+# includes sizes (by quick-fedora-mirror) and the fullfiletimelist (by
+# quick-fedora-hardlink), so don't use expressions that would match those
+# metadata (which are digit strings and single characters). Example is a heavy
+# filter which gives you an x86_64-only mirror with source packages, debuginfo
+# packages, Alpha and Beta releases, and most image files excluded.
+# FILTEREXP='(/i386|/armhfp|/source|/SRPMS|/debug/|\.iso|\.img|\.qcow2|\.raw\.xz|\.box|/releases/test)'

--- a/script/fedora.py
+++ b/script/fedora.py
@@ -1,0 +1,66 @@
+# This script does not follow the general command line argument convention. 
+
+import sys
+import json
+import datetime, time
+import os
+import fcntl
+
+Name			=	sys.argv[1]
+LocalPath		=	sys.argv[2]
+RemotePath		=	sys.argv[3]
+TimefilePath	=	sys.argv[4]
+StatusPath		=	sys.argv[5]
+
+def writer(statuscode):
+	if not os.path.exists(StatusPath):
+		output_file = open(StatusPath, 'a+')
+		output_file.close()
+
+	output_file = open(StatusPath, 'r+')
+
+	fcntl.flock(output_file.fileno(), fcntl.LOCK_EX)
+
+	try:
+		content = json.loads(output_file.read())
+	except:
+		content = []
+
+	newstatus = {
+		'name': Name,
+		'statuscode': statuscode,
+		'time': time.time()
+	}
+
+	insert = True
+	for i in range(len(content)):
+		if content[i]['name'] == Name:
+			content[i] = newstatus
+			insert = False
+	if insert: content.append(newstatus)
+
+	content = sorted(content, key = lambda t:t['name'])
+
+	output_file.seek(0)
+
+	output_file.write(json.dumps(content))
+
+	output_file.truncate() 
+
+	output_file.close()
+
+command_literal = "./quick-fedora-mirror --timefile {} --destination-dir {} --upstream {} {}"
+		.format(TimefilePath, LocalPath, RemotePath, "" if os.path.exists(TimefilePath) else "-a")
+	
+print("	[{}] run command {}.".format(Name, command_literal))
+
+writer(-1)
+
+statuscode = os.system(command_literal) >> 8
+
+writer(statuscode)
+
+if statuscode != 0:
+	print("	[{}] failed with error code {}."
+				.format(Name, statuscode))
+	exit(233)

--- a/script/quick-fedora-mirror
+++ b/script/quick-fedora-mirror
@@ -1,0 +1,1398 @@
+#!/bin/zsh
+# Simple script to grab the file list from Fedora and rsync everything that's
+# changed since the last time we pulled.
+#
+# Originally written by Jason Tibbitts <tibbs@math.uh.edu> in 2016.
+# Donated to the public domain.  If you require a statement of license, please
+# consider this work to be licensed as "CC0 Universal", any version you choose.
+
+# Modified by Jim Wang, 2017. Follow original copyright policy.
+# Added --destination-dir, --timefile, --upstream option.
+
+# Variables in upper case are user configurables.
+
+# ZSHISM? Turn on empty globs
+set -G
+export LANG=C
+# ZSHISM? newline for IFS.
+IFS=$'\n'
+
+# Do this very early
+starttime=$(date +%s)
+
+# Debug output;
+# Level 0: nothing except errors.
+# Level 1: lvl0 unless there is a tranfer, and then basic info and times.
+# Output goes to a file which may be spit out at the end of the run.
+# Level >= 2: Always some info, output to the terminal.
+db1 () {
+    if (( VERBOSE >= 2 )); then
+        echo $*
+    elif (( VERBOSE >= 1 )); then
+        echo $* >> $outfile
+    fi
+    # Otherwise output nothing....
+}
+db1f () { db1 $(printf $*); }
+
+db2 () { (( VERBOSE >= 2 )) && echo $*}
+db2f () { (( VERBOSE >= 2 )) && printf $*}
+db3 () { (( VERBOSE >= 3 )) && echo '>>' $*}
+db4 () { (( VERBOSE >= 4 )) && echo '>>>>' $*}
+sep () { (( VERBOSE >= 2 )) && echo '============================================================'}
+
+logwrite () {
+    # Send logging info to the right place
+    if [[ -n $LOGJOURNAL ]]; then
+        echo $* >&3
+    elif [[ -n $LOGFILE && -w $LOGFILE ]]; then
+        echo $(date '+%b %d %T') $* >> $LOGFILE
+    fi
+}
+
+logit () {
+    # Basic logging function
+    local item=$1
+    shift
+    local err=''
+    [[ $item == 'E' ]] && err='ERR:'
+    [[ $item == 'e' ]] && err='Err:'
+
+    if [[ $LOGITEMS =~ $item || $LOGITEMS =~ '@' ]]; then
+       logwrite $err $*
+   fi
+   if (( VERBOSE >= 3 )); then
+       db3 Log: $err $*
+   fi
+}
+
+retcheck () {
+    local ret=$1
+    local prg=''
+    [[ -n $2 ]] && prg="$2 "
+
+    if [[ $ret -ne 0 ]]; then
+        db1 "${prg}failed at $functrace[1]: with return $ret"
+        logit E "${prg}call failed at $functrace[1]: with return $ret"
+    fi
+}
+
+lock () {
+    eval "exec 9>>$1"
+    flock -n 9 && return 0
+    return 1
+}
+
+finish () {
+    # Finish up.  Dump the output file to stdout unless an argument is passed.
+    db1 "========================="
+    db1 "Mirror finished: $(date)"
+    logit R "Run end."
+    if [[ -z $1 ]]; then
+        cat $outfile
+    fi
+    exit 0
+}
+
+filter () {
+    # Client-side file list filtering.
+    if [[ -n $FILTEREXP ]]; then
+        db4 filtering $1
+        sed --in-place=-prefilter -r -e "\,$FILTEREXP,d" $1
+    fi
+}
+
+hr_b () {
+    # Produce human-readable byte counts
+    # Yes, this has a bug at 1024EB
+    typeset -F2 out
+
+    if [[ $1 -lt 1024 ]]; then
+        echo ${1}B
+        return
+    fi
+
+    out=$(( $1 / 1024. ))
+    for unit in KB MB GB TB PB EB; do
+        (( $out < 1024 )) && break
+        out=$(( out / 1024. ))
+    done
+
+    echo ${out}${unit}
+}
+
+hr_s () {
+    # Produce human-readable second counts
+    typeset -F2 out=$1
+
+    if [[ $1 -lt 60 ]]; then
+        echo ${1}s
+        return
+    fi
+
+    out=$(( $1 / 60. ))
+    if [[ $out -lt 60 ]]; then
+        echo ${out}m
+        return
+    fi
+
+    out=$(( $out / 60. ))
+    echo ${out}h
+}
+
+parse_rsync_stats () {
+    # Parse some of the statistics that rsync gives us.
+    # Takes an rsync output log (stdout) as an argument.
+    # No return value, but sill set several global variables:
+    #   rsfilestransferred
+    #   rsfilesize
+    #   rstotalbytesreceived
+    #   rstotalbytessent
+    #   rsfilelistgentime
+    #   rsfilelisttransfertime
+    #   rstransferspeed
+    #   rsspeedup
+    # These will all be set unset if not present in the given log.
+    #
+    # Here's the full block of info that rsync provides:
+    #
+    # rsync[30399] (receiver) heap statistics:
+    #   arena:         311296   (bytes from sbrk)
+    #   ordblks:            2   (chunks not in use)
+    #   smblks:             1
+    #   hblks:              2   (chunks from mmap)
+    #   hblkhd:        532480   (bytes from mmap)
+    #   allmem:        843776   (bytes from sbrk + mmap)
+    #   usmblks:            0
+    #   fsmblks:           48
+    #   uordblks:      178272   (bytes used)
+    #   fordblks:      133024   (bytes free)
+    #   keepcost:      131200   (bytes in releasable chunk)
+    #
+    # rsync[30394] (generator) heap statistics:
+    #   arena:         311296   (bytes from sbrk)
+    #   ordblks:            2   (chunks not in use)
+    #   smblks:             1
+    #   hblks:              2   (chunks from mmap)
+    #   hblkhd:        532480   (bytes from mmap)
+    #   allmem:        843776   (bytes from sbrk + mmap)
+    #   usmblks:            0
+    #   fsmblks:           48
+    #   uordblks:      178208   (bytes used)
+    #   fordblks:      133088   (bytes free)
+    #   keepcost:      131200   (bytes in releasable chunk)
+    #
+    # Number of files: 11,140 (reg: 9,344, dir: 1,796)
+    # Number of created files: 1,329 (reg: 1,327, dir: 2)
+    # Number of deleted files: 0
+    # Number of regular files transferred: 1,182
+    # Total file size: 165,405,056,029 bytes
+    # Total transferred file size: 3,615,178,247 bytes
+    # Literal data: 3,229,943,512 bytes
+    # Matched data: 385,234,735 bytes
+    # File list size: 468,791
+    # File list generation time: 0.217 seconds
+    # File list transfer time: 0.000 seconds
+    # Total bytes sent: 1,249,286
+    # Total bytes received: 3,231,373,895
+    #
+    # sent 1,249,286 bytes  received 3,231,373,895 bytes  81,838,561.54 bytes/sec
+    # total size is 165,405,056,029  speedup is 51.17
+
+    local log=$1
+
+    # Number of regular files transferred: 1
+    unset rsfilestransferred
+    rsfilestransferred=$(awk '/^Number of regular files transferred:/ {print $6; exit}' $log)
+
+    # Total file size: 10,174,746 bytes
+    unset rsfilesize
+    rsfilesize=$(awk '/^Total file size: (.*) bytes/ {print $4; exit}' $log | sed -e 's/,//g')
+
+    # Total bytes received: 2,425,728
+    unset rstotalbytesreceived
+    rstotalbytesreceived=$(awk '/^Total bytes received: (.*)/ {print $4; exit}' $log | sed -e 's/,//g')
+
+    # Total bytes sent: 384,602
+    unset rstotalbytessent
+    rstotalbytessent=$(awk '/^Total bytes sent: (.*)/ {print $4; exit}' $log | sed -e 's/,//g')
+
+    # File list generation time: 0.308 seconds
+    unset rsfilelistgentime
+    rsfilelistgentime=$(awk '/^File list generation time: (.*) seconds/ {print $5; exit}' $log)
+
+    # File list transfer time: 0.000 seconds
+    unset rsfilelisttransfertime
+    rsfilelisttransfertime=$(awk '/^File list transfer time: (.*) seconds/ {print $5; exit}' $log)
+
+    # sent 71 bytes  received 2,425,728 bytes  156,503.16 bytes/sec
+    unset rstransferspeed
+    rstransferspeed=$(awk '/^sent .* bytes .* received .* bytes (.*) bytes\/sec$/ {print $7; exit}' $log \
+                      | sed -e 's/,//g')
+
+    # total size is 10,174,746  speedup is 4.19
+    unset rsspeedup
+    rsspeedup=$(awk '/^total size is .* speedup is (.*)$/ {print $7; exit}' $log)
+}
+
+do_rsync () {
+    # The main function to do a transfer
+    # Accepts four options:
+    #   1) The source repository
+    #   2) The destination directory
+    #   3) The list of files
+    #   4) The name of an array containing additional rsync options
+    #
+    # This may sleep and retry when receiving an error.
+    # Returns the last rsync return code; 0 if no error.
+    #
+
+    local src=$1 dest=$2 files=$3 opts=$4
+    local runcount=0
+    local log=$(mktemp -p . rsync-out-XXXXXX.log)
+    local errlog=$(mktemp -p . rsync-err-XXXXXX.log)
+    local sleep rr rvbash rvzsh
+
+    local -a verboseopts
+
+    # These add to the default rsync verbosity
+    (( VERBOSE >= 7 )) && verboseopts+=(--progress)
+    (( VERBOSE >= 5 )) && verboseopts+=(-v)
+    (( VERBOSE >= 4 )) && verboseopts+=(-v)
+
+    # Usually we won't want to see this.
+    (( VERBOSE <= 3 )) && verboseopts+=(--no-motd)
+
+    flopts=(--files-from=$files)
+
+    while true; do
+        runcount=$(( runcount+1 ))
+        # ZSHISM:  (P) flag to act on a variable by name.  Sadly, bash has
+        # broken array handling.   bash 4.3 has local -n for this.  Older bash
+        # needs hacks, or eval.  More info:
+        # https://stackoverflow.com/questions/1063347/passing-arrays-as-parameters-in-bash
+        # Or just use a freaking global.
+
+        # We have to do this separately because you can't redirect to /dev/stderr when running under sudo.
+        db3 Calling $RSYNC $RSYNCOPTS $verboseopts $flopts ${(P)opts} $src $dest
+        logit c calling $RSYNC $RSYNCOPTS $verboseopts $flopts ${(P)opts} $src $dest
+        if (( VERBOSE >= 5 )); then
+            $RSYNC $RSYNCOPTS $verboseopts $flopts ${(P)opts} $src $dest | tee $log
+            rvbash="${PIPESTATUS[0]}" rvzsh="${pipestatus[1]}" rr=$rvbash$rvzsh
+        elif (( VERBOSE >= 2 )); then
+            $RSYNC $RSYNCOPTS $verboseopts $flopts ${(P)opts} $src $dest >> $log
+            rvbash="${PIPESTATUS[0]}" rvzsh="${pipestatus[1]}" rr=$rvbash$rvzsh
+        else
+            $RSYNC $RSYNCOPTS $verboseopts $flopts ${(P)opts} $src $dest >> $log 2>> $errlog
+            rvbash="${PIPESTATUS[0]}" rvzsh="${pipestatus[1]}" rr=$rvbash$rvzsh
+        fi
+
+        # We should ignore; 0 (obviously), 24
+        # If we retried on 24 (missing files on server) we'd never make progress.
+        # We should retry: 5 10 23 30 35
+        if (( rr == 0 )); then
+            break
+        elif (( rr == 24 )); then
+            logit e "rsync says source files vanished; ignoring"
+            break
+        elif (( rr == 5 || rr == 10 || rr == 23 || rr == 30 || rr == 35 )); then
+            # First see if we've already tried too many times
+            if (( runcount >= MAXRETRIES )); then
+                logit E rsync from $REMOTE failed
+                (>&2 echo "Could not sync from $REMOTE")
+                [[ -f $errlog ]] && (>&2 cat $errlog)
+                return $rr
+            fi
+            sleep=$(( 2 ** runcount ))
+            logit e "rsync returned $rr (retryable), sleeping for $sleep"
+            db2 rsync failed: sleeping for $sleep
+            sleep $sleep
+        else
+            # Some other code we didn't anticipate
+            logit E "rsync returned $rr.  This is not recoverable."
+            (>&2 echo "rsync returned $rr.  This is not recoverable."
+                [[ -f $errlog ]] && cat $errlog
+            )
+            return $rr
+        fi
+    done
+
+    logit C rsync call completed succesfully with return $rr
+
+    parse_rsync_stats $log
+    return $rr
+}
+
+parse_args () {
+    # Process arguments, setting all sorts of globals
+    while [[ $# > 0 ]]; do
+        opt=$1
+        case $opt in
+            -a)
+                alwayscheck=1
+                ;;
+            -c)
+                cfgfile=$2
+                shift
+                if [[ ! -r $cfgfile ]]; then
+                    (>&2 echo Cannot read $cfgfile)
+                    exit 1
+                fi
+                ;;
+            -d) # Debugging
+                verboseopt=$2
+                shift
+                ;;
+            -n)
+                rsyncdryrun=1
+                skipdelete=1
+                skiptimestamp=1
+                ;;
+            -N)
+                skipdelete=1
+                skiptimestamp=1
+                ;;
+            -t)
+                backdate=$2
+                alwayscheck=1
+                shift
+                ;;
+            -T)
+                backdate=$(date -d "$2" +%s)
+                alwayscheck=1
+                shift
+                ;;
+            --checkin-only)
+                skiptransfer=1
+                skipdelete=1
+                skiptimestamp=1
+                forcecheckin=1
+                ;;
+            --destination-dir)
+                DESTD=$2
+				shift
+                ;;
+            --timefile)
+                TIMEFILE=$2
+				shift
+                ;;
+            --upstream)
+                REMOTE=$2
+				shift
+                ;;
+            --dir-times)
+                updatealldirtimes=1
+                ;;
+            --refresh)
+                skipdelete=1
+                skiptimestamp=1
+                skipcheckin=1
+                refreshpattern=$2
+                shift
+                ;;
+            --dump-mm-checkin)
+                # Just for the test suite; dump the raw payload to the given
+                # filename with the module name appended.
+                dumpmmcheckin=$2
+                shift
+                ;;
+            --no-paranoia)
+                # Don't backdate the last mirrortime
+                noparanoia=1
+                ;;
+            *)
+                (>&2 echo "Unrecognized argument.")
+                exit 1
+                ;;
+        esac
+        shift
+    done
+}
+
+read_config () {
+    # Load up the configuration file from any of a number of locations
+    local file
+    for file in \
+        $cfgfile \
+        /etc/quick-fedora-mirror.conf \
+        ~/.config/quick-fedora-mirror.conf \
+        $(dirname $0)/quick-fedora-mirror.conf \
+        ./quick-fedora-mirror.conf; \
+    do
+        if [[ -r $file ]]; then
+            source $file
+            cfgfile=$file
+            break
+        fi
+    done
+
+    # Override some settings with previously parsed command-line options
+    [[ -n $verboseopt ]] && VERBOSE=$verboseopt
+
+    # Check that the required parameters were provided
+    if [[ -z $DESTD ]]; then
+        (>&2 echo "You must define DESTD in your configuration file ($cfgfile).")
+    fi
+    if [[ -z $TIMEFILE ]]; then
+        (>&2 echo "You must define TIMEFILE in your configuration file ($cfgfile) or through command line.")
+    fi
+
+    # Set some other general variables based on the value of provided
+    # configuration settings
+    [[ -z $CHECKIN_SITE ]] && skipcheckin=1
+    [[ -z $MAXCHECKINRETRIES ]] && MAXCHECKINRETRIES=$MAXRETRIES
+}
+
+set_default_vars () {
+    # Set various defaults before the configuration file is loaded.
+
+    # Mapping from module names to directories under fedora-buffet
+    # ZSHISM (initialize associative array)
+    typeset -g -A MODULEMAPPING
+    typeset -g -A MIRRORMANAGERMAPPING
+    typeset -g -A MIRRORMANAGERMODULEMAPPING
+
+    MODULEMAPPING=(
+    fedora-alt          alt
+    fedora-archive      archive
+    fedora-enchilada    fedora
+    fedora-epel         epel
+    fedora-secondary    fedora-secondary
+    )
+
+    MIRRORMANAGERMAPPING=(
+    fedora-alt          'fedora other'
+    fedora-archive      'fedora archive'
+    fedora-enchilada    'fedora linux'
+    fedora-epel         'fedora epel'
+    fedora-secondary    'fedora secondary arches'
+    )
+
+    # Mirrormanager has a weird prefix for "fedora-enchilada", so copy the
+    # existing module mapping and alter it
+    MIRRORMANAGERMODULEMAPPING=(${(kv)MODULEMAPPING})
+    MIRRORMANAGERMODULEMAPPING[fedora-enchilada]="fedora/linux"
+
+    # Default arguments; override in quick-fedora-mirror.conf
+    VERBOSE=0
+    LOGITEMS=aeElrR
+
+    DESTD=
+    TIMEFILE=
+
+    CHECKIN_HOST=$(hostname)
+    CURL=/usr/bin/curl
+    FILELIST='fullfiletimelist-$mdir'
+    EXTRAFILES=(fullfilelist imagelist-\$mdir)
+    MIRRORMANAGER=https://admin.fedoraproject.org/mirrormanager/xmlrpc
+    REMOTE=rsync://dl.fedoraproject.org
+    RSYNC=/usr/bin/rsync
+    WARNDELAY=$((60 * 60 * 24))
+    MAXRETRIES=10
+
+    rsyncver=$(rsync --version | head -1 | awk '{print $3}')
+    if [[ $rsyncver == 3.1* ]]; then
+        RSYNCOPTS=(-aSH -f 'R .~tmp~' --stats --preallocate --delay-updates --out-format='@ %i  %n%L')
+    else
+        RSYNCOPTS=(-aSH -f 'R .~tmp~' --stats --delay-updates --out-format='@ %i  %n%L')
+    fi
+
+    MASTERMODULE=fedora-buffet
+    MODULES=(fedora-enchilada fedora-epel)
+}
+
+check_file_list_version () {
+    # Look at the file list to see if we can handle it
+    #
+    # Takes the file list name.
+    # Returns 0 if we can handle it, 1 if we can't.
+    local max_fl_version=3
+    local fl=$1
+
+    if [[ ! -f $fl ]]; then
+        (>&2 echo "Cannot check file list \"$fl\".  Exiting.")
+        exit 1
+    fi
+
+    local flversion=$(awk -F '\t' '/^\[Version/ {s=1; next} /^$/ {exit} {if (s) print $0}' < $fl)
+    if [[ "$flversion" -le $max_fl_version ]]; then
+        return
+    fi
+
+    # Either it is too new or we just can't parse it, so quit.
+    (>&2 echo "File list from the mirror cannot be processed by this script.  Exiting.")
+    exit 1
+}
+
+fetch_file_lists () {
+    # Download the file list for each configred module
+    # Will set the global variable "checksums" containing the checksum of the
+    # file list of each module.
+
+    local extra flname module rsyncreturn
+
+    sep
+    logit o Remote file list download start
+    db2 Downloading file lists
+    # ZSHISM (declare associative array)
+    typeset -g -A checksums
+    for module in $MODULES; do
+        # ZSHISM? (associative array indexing)
+        moduledir=$MODULEMAPPING[$module]
+        mkdir $moduledir
+        flname=${FILELIST/'$mdir'/$moduledir}
+        if [[ -f $DESTD/$moduledir/$flname ]]; then
+            cp -p $DESTD/$moduledir/$flname $moduledir
+            # ZSHISM (assign assoc. array value)
+            checksums[$module]=$(sha1sum $DESTD/$moduledir/$flname | cut -d' ' -f1)
+        fi
+
+        echo $moduledir/$flname >> filelist-transferlist
+    done
+
+    extra=(--no-dirs --relative --compress)
+    do_rsync $REMOTE/$MASTERMODULE/ . filelist-transferlist extra
+    rsyncreturn=$?
+    if [[ $rsyncreturn -ne 0 ]]; then
+        (>&2 echo "rsync finished with nonzero exit status.\nCould not retrieve file lists.")
+        logit E Aborting due to rsync failure while retrieving file lists
+        finish
+    fi
+
+    # Log very basic stats
+    logit s "File list download: $(hr_b $rstotalbytesreceived) received, $(hr_b $rstransferspeed)/s"
+
+    # Check that we can handle the downloaded lists
+    for module in $MODULES; do
+        moduledir=$MODULEMAPPING[$module]
+        flname=${FILELIST/'$mdir'/$moduledir}
+        check_file_list_version $moduledir/$flname
+    done
+
+    # rsync won't transfer those files to the current directory, so move them and
+    # clean up.
+    mv */* .
+    rmdir * 2> /dev/null
+    logit o Remote file list download: end
+}
+
+checkin_build_inner_payload () {
+    # Build the inner json payload
+    # Takes the module name and the name of the output file to use
+    local module=$1
+    local mm=$2
+    local checkinhost=$3
+
+    local moduledir=$MIRRORMANAGERMODULEMAPPING[$module]
+    local mmcheckin=$MIRRORMANAGERMAPPING[$module]
+
+    cat >$mm <<EOF
+{
+    "$mmcheckin": {
+        "dirtree": {
+EOF
+
+    # Output the data for each directory.  MM doesn't want the
+    # directory name.
+    for l in $(cat alldirs-$module); do
+        echo "            \"${l/$moduledir\/}\": {}," >>$mm
+    done
+
+    # The data sent by report_mirror always includes a blank directory; add it
+    # manually here which conveniently means we don't have to deal with the
+    # trailing comma.  And after that, the various parameters mirrormanager
+    # wants.
+    cat >>$mm <<EOF
+            "": {}
+        },
+        "enabled": "1"
+    },
+    "global": {
+        "enabled": "1",
+        "server": "$MIRRORMANAGER"
+    },
+    "host": {
+        "enabled": "1",
+        "name": "$checkinhost"
+    },
+    "site": {
+        "enabled": "1",
+        "name": "$CHECKIN_SITE",
+        "password": "$CHECKIN_PASSWORD"
+    },
+    "stats": {},
+    "version": 0
+}
+EOF
+}
+
+checkin_encode_inner_payload () {
+    # Compress and encode the inner payload.
+    # Takes the input and output filenames
+
+    local in=$1
+    local out=$2
+
+    # The xmlrpc endpoint requires that the payload be bzip2 compressed
+    bzip2 $mm
+
+    # base64 encode
+    base64 --wrap=0 $in.bz2 > $in.bz2.b64
+
+    # change '+' to '-'  and '/' to '_'
+    tr '+/' '-_' < $in.bz2.b64 > $out
+
+    rm $in.bz2 $in.bz2.b64
+}
+
+checkin_build_outer_payload () {
+    # Wrap the encoded payload in just the right xml
+    # Takes input and output filenames
+
+    local in=$1
+    local out=$2
+
+    cat >>$out <<EOF
+<?xml version='1.0'?>
+<methodCall>
+<methodName>checkin</methodName>
+<params>
+<param>
+EOF
+    echo -n "<value><string>" >>$out
+
+    cat <$in >>$out
+
+    cat >>$out <<EOF
+</string></value>
+</param>
+</params>
+</methodCall>
+EOF
+}
+
+checkin_upload_payload () {
+    # Now actually upload the payload
+    # We have to remove the Expect: header that curl sends but which mirrormanager cannot handle
+    local payload=$1
+    local module=$2
+    local -a curlopts
+    local curlret
+
+    logit M "Making xmlrpc call for $module"
+    curlopts=(--silent)
+    (( VERBOSE >= 4 )) && curlopts=(--verbose)
+    $CURL $curlopts -H "Expect:" -H "Content-Type: text/xml" --data @$mx $MIRRORMANAGER > curl.out
+    curlret=$?
+    if [[ $curlret -ne 0 ]]; then
+        logit e "Checkin failure: curl returned $curlret"
+        (>&2 echo "Checkin failure: curl returned $curlret")
+        return 2
+    fi
+
+    # Parse the output to see if we got any useful return
+    # The sed call attempts to strip xml tags.  Easily fooled but we don't expect
+    # any complicated return from mirrormanager.
+    sed -e 's/<[^>]*>//g' curl.out > curl.noxml
+    grep -q -i successful curl.noxml
+
+    if [[ $? -ne 0 ]]; then
+        db1 "Mirrormanager checkin for $module did not appear to succeed."
+        logit e "Doesn't look like we got a good return from mirrormanager."
+        logit e $(cat curl.noxml)
+        return 1
+    fi
+    return 0
+}
+
+checkin_module () {
+    # Perform the mirrormanager checkin for a particular module
+    local module=$1
+
+    local mm=mirrormanager-payload-$module
+    local mx=mirrormanager-xmlrpc-$module
+    local moduledir=$MODULEMAPPING[$module]
+
+    if [[ ! -f alldirs-$module ]]; then
+        # We were asked to check in a module that we hadn't previously
+        # processed, which should not happen.
+        logit E "Cannot perform checkin for $module; no directory list exists."
+        return
+    fi
+
+    # Determine the "mirrormanager hostname" to use for this checkin.
+    # Different modules can be set up under different "hosts" in mirrormanager,
+    # even though these might all be on the same machine.  This works around
+    # problems mirrormanager has when crawling machines which mirror
+    # everything.
+    # ZSHISM: This uses "(P)"; the equivalent in bash is "!".
+    local checkinhost=$CHECKIN_HOST
+    local hostspecificvar=CHECKIN_HOST_${module//-/_}
+    if [[ -n ${(P)hostspecificvar} ]]; then
+        checkinhost=${(P)hostspecificvar}
+    fi
+
+    db3 "Performing mirrormanager checkin for $module (in $moduledir) as $checkinhost"
+    logit M "Processing $module (in $moduledir) as $checkinhost"
+
+    # Construct the checkin payload
+    checkin_build_inner_payload $module $mm $checkinhost
+    checkin_encode_inner_payload $mm $mm.enc
+    checkin_build_outer_payload $mm.enc $mx
+
+    # For the test suite, just dump the checkin info and bail
+    if [[ -n $dumpmmcheckin ]]; then
+        cat $mx > $dumpmmcheckin-$module
+        return
+    fi
+
+    # Try to check in until we've retried too often.
+    local retries=1
+    while true; do
+        checkin_upload_payload $mx $module
+
+        if [[ $? -eq 0 ]]; then
+            break
+        fi
+
+        if (( retries >= MAXRETRIES )); then
+            logit E "Could not complete checkin after $MAXCHECKINRETRIES tries."
+            break
+        fi
+
+        logit e "Checkin attempt $retries failed.  Will retry."
+        retries=$(( retries +1 ))
+        sleep $(( 2*retries ))
+    done
+
+    logit M "Processing $module: end"
+}
+
+awk_extract_newer_dirs_restricted () {
+    local inf=$1
+    local outf=$2
+    local mdir=$3
+
+    local last=0
+    [[ -n $4 ]] && last=$4
+
+    awk -F '\t' " \
+        /\\[Files/ {s=1;next}
+        /^\$/ {s=0;next}
+        { if (s && \$1 >= $last \
+            && (\$2 == \"d\" || \$2 == \"d-\" || \$2 == \"d*\")) \
+            print \"$mdir/\" \$4 \
+        }" \
+        < $inf > $outf
+    retcheck $? awk
+}
+
+awk_extract_newer_dirs_no_restricted () {
+    local inf=$1
+    local outf=$2
+    local mdir=$3
+
+    local last=0
+    [[ -n $4 ]] && last=$4
+
+     awk -F '\t' " \
+        /\\[Files/ {s=1;next} \
+        /^\$/ {s=0;next} \
+        { if (s && \$1 >= $last \
+            && (\$2 == \"d\")) \
+            print \"$mdir/\" \$4 \
+        }" \
+        < $inf > $outf
+    retcheck $? awk
+}
+
+awk_extract_newer_files_restricted () {
+    local inf=$1
+    local outf=$2
+    local mdir=$3
+
+    local last=0
+    [[ -n $4 ]] && last=$4
+
+    awk -F '\t' "/\\[Files/ {s=1;next} \
+        /^\$/ {s=0;next} \
+        {if (s && \$1 >= $last && \
+            (\$2 == \"f\" || \$2 == \"f-\" || \$2 == \"f*\" \
+            || \$2 == \"l\" || \$2 == \"l-\" || \$2 == \"l*\" \
+            )) \
+            print \"$mdir/\" \$4 \"\t\" \$3 \
+        } \
+        " $inf > $outf
+    retcheck $? awk
+}
+
+awk_extract_newer_files_no_restricted () {
+    local inf=$1
+    local outf=$2
+    local mdir=$3
+
+    local last=0
+    [[ -n $4 ]] && last=$4
+
+    awk -F '\t' "/\\[Files/ {s=1;next} \
+        /^\$/ {s=0;next} \
+        {if (s && \$1 >= $last && \
+            (\$2 == \"f\" \
+            || \$2 == \"l\" \
+            )) \
+            print \"$mdir/\" \$4 \"\t\" \$3 \
+        } \
+        " $inf > $outf
+    retcheck $? awk
+}
+
+process_remote_file_list () {
+    # Extract various file and directory lists from the master file list
+    #
+    # This will also handle ignoring restricted or pre-bitflip content if
+    # necessary.
+    #
+    # Will create the following files:
+    #   allfilesizes-$module
+    #   allfiles-$module
+    #   alldirs-$module
+    #   newdirs-$module
+    local module=$1
+    local moduledir=$2
+
+    db3 Extracting file and directory lists for $module.
+
+    if [[ -n $PREBITFLIP ]]; then
+        db4 "Directories (pre-bitflip included)"
+        awk_extract_newer_dirs_restricted $fl alldirs-$module $moduledir
+
+        db4 "New dirs (pre-bitflip included)"
+        awk_extract_newer_dirs_restricted $fl newdirs-$module $moduledir $LASTTIME
+
+        db4 "Files (pre-bitflip included)"
+        awk_extract_newer_files_restricted $fl allfilesizes-$module $moduledir
+
+        db4 "New files (pre-bitflip included)"
+        awk_extract_newer_files_restricted $fl newfilesizes-$module $moduledir $LASTTIME
+    else
+        # All dirs, unrestricted only
+        db4 "Directories (pre-bitflip excluded)"
+        awk_extract_newer_dirs_no_restricted $fl alldirs-$module $moduledir
+
+        db4 "New dirs (pre-bitflip excluded)"
+        awk_extract_newer_dirs_no_restricted $fl newdirs-$module $moduledir $LASTTIME
+
+        db4 "Files (pre-bitflip excluded)"
+        awk_extract_newer_files_no_restricted $fl allfilesizes-$module $moduledir
+
+        db4 "New files (pre-bitflip excluded)"
+        awk_extract_newer_files_no_restricted $fl newfilesizes-$module $moduledir $LASTTIME
+    fi
+
+    # Filter the lists if needed
+    filter alldirs-$module
+    filter newdirs-$module
+    filter allfilesizes-$module
+    filter newfilesizes-$module
+
+    # Produce the file lists without sizes.
+    awk -F '\t' '{print $1}' allfilesizes-$module > allfiles-$module; retcheck $? awk
+    awk -F '\t' '{print $1}' newfilesizes-$module > newfiles-$module; retcheck $? awk
+}
+
+remove_filelists_from_file () {
+    # Remove the file from $FILELIST and anything given by $EXTRAFILES.
+    # Takes:
+    #   file to modify
+    #   directory of current module (for substituting $mdir)
+    # Modifies the file directly
+    # Calls egrep -v in a loop.  Generally this is called on files of no more
+    # than a few thousand lines, so performance shouldn't be an issue.
+    local f=$1
+    local moduledir=$2
+    local tmp=$f.rfff
+    local fl
+
+    for fl in $FILELIST $EXTRAFILES; do
+        fl=${fl/'$mdir'/$moduledir}
+        egrep -v "^[^/]*/$fl" $f > $tmp
+        mv $tmp $f
+    done
+
+    rm -f $tmp
+}
+
+process_module () {
+    # Determine what needs to be transferred and removed from a single module.
+    #
+    # Takes the name of the module to process, returns nothing.
+    #
+    # Sets the following globals:
+    # changed_modules
+    #
+    # Will leave the following lists in the temporary dir for use by other
+    # functions:
+    #
+    # May leave other files, but don't depend on them.
+
+    local module=$1
+    # ZSHISM? (associative array indexing)
+    local moduledir=$MODULEMAPPING[$module]
+
+    local fl=${FILELIST/'$mdir'/$moduledir}
+    local totallines=0
+    local linecount linecount2
+    local extra
+
+    if [[ -z $alwayscheck && \
+            -n $checksums[$module] && \
+            $(sha1sum $fl | cut -d' ' -f1) == $checksums[$module] ]]; then
+        logit N No change in file list for $module
+        db2 No change in file list checksum.  Skipping $module.
+        continue
+    fi
+
+    sep
+    logit P Processing start: $module
+    db2 Processing $module
+    changed_modules+=$module
+
+    # XXX Could this go in with the version check?
+    tail -2 $fl | grep -q '^\[End\]$'
+    if (( ? != 0 )); then
+        (>&2 echo "No end marker.  Corrupted file list?"
+        echo Skipping $module.)
+        return
+    fi
+
+    process_remote_file_list $module $moduledir
+
+    linecount=$(wc -l < allfiles-$module)
+    linecount2=$(wc -l < alldirs-$module)
+    db2f "Total on server:       %7d files, %4d dirs.\n" $linecount $linecount2
+
+    linecount=$(wc -l < newfiles-$module)
+    linecount2=$(wc -l < newdirs-$module)
+    db2f "New on server:         %7d files, %4d dirs.\n" $linecount $linecount2
+
+    # Add extra files to the transfer list
+    echo $moduledir/$fl >> newfiles-$module
+    for extra in $EXTRAFILES; do
+        extra=${extra/'$mdir'/$moduledir}
+        echo $moduledir/$extra >> newfiles-$module
+    done
+    cat newfiles-$module >> transferlist-$module
+    cat newdirs-$module >> transferlist-$module
+    totallines=$((totallines+linecount+linecount2+1))
+
+    if [[ -d $DESTD/$moduledir ]]; then
+        # XXX Hoist this out to a separate function
+        # process_local_file_list $module $moduledir
+        db3 Generating local file/dir list
+        logit l Generating file list start: $module
+
+        # Traverse the filesystem only once
+        pushd $DESTD
+        find $moduledir/* -printf '%y\t%p\t%s\n' > $tempd/localfulllist-$module
+        popd
+
+        # Now extract file and dir lists from that
+        awk -F '\t' '{if ($1 == "d") {print $2}}' < localfulllist-$module > localdirs-$module
+        awk -F '\t' '{if ($1 == "f" || $1 == "l") {print $2}}' < localfulllist-$module > localfiles-$module
+        awk -F '\t' '{if ($1 == "f" || $1 == "l") {print $2 "\t" $3}}' < localfulllist-$module > localfilesizes-$module
+
+        # Look for stray .~tmp~ dirs
+        if [[ -z $NORSYNCRECOVERY ]]; then
+            grep '\.~tmp~' localdirs-$module > staletmpdirs-$module
+            grep '\.~tmp~' localfiles-$module > staletmpfiles-$module
+        fi
+
+        if [[ -s staletmpdirs-$module ]]; then
+            db2 Possibly aborted rsync run.  Cleaning up.
+            logit a "cleaning up previous aborted run: $(wc -l < staletmpfiles-$module) file(s)."
+
+            # Move the files in those tmpdirs a level up if a file with the
+            # same name doesn't exist.  We don't update the file lists because
+            # we want rsync to re-check those files and possibly fix up the
+            # permissions.  The dirs will be cleaned up later.
+            # Note that this _may_ leave a few files around which should not be
+            # there.  They will of course be cleaned up at the next run.
+            # XXX We could do better by comparing the stale files against the
+            #   to-be-fransferred list, but it's probably not worth it.
+            for dir in $(cat staletmpdirs-$module); do
+                pushd $DESTD/$dir
+                for file in *; do
+                    if [[ ! -f ../$file ]]; then
+                        logit A Saving previous download $file
+                        db3 Saving previous download: $file
+                        mv $file ..
+                    fi
+                done
+                popd
+            done
+        logit l Generating file list end: $module
+        fi
+
+        # Find files on the client which don't exist on the server
+        sort allfiles-$module allfiles-$module localfiles-$module \
+            | uniq -u  > deletefiles-$module
+        remove_filelists_from_file deletefiles-$module $moduledir
+        cat deletefiles-$module >> master-deletefiles
+
+        # Find dirs on the client which don't exist on the server
+        sort alldirs-$module alldirs-$module localdirs-$module \
+            | uniq -u > deletedirs-$module
+        cat deletedirs-$module >> master-deletedirs
+
+        # Extract dirnames of every file and dir in the delete lists, and all of their parents.
+        if [[ -n $updatealldirtimes ]]; then
+            cat alldirs-$module >> master-updatetimestamps
+        else
+            awk '{dn($0)} function dn(p) { while (sub(/\/[^\/]*\]?$/, "", p)) print p }' \
+                deletefiles-$module deletedirs-$module \
+                | sort -u > updatetimestamps-$module
+            cat updatetimestamps-$module >> master-updatetimestamps
+        fi
+
+        # Find files on the server which are missing on the client
+        sort localfiles-$module localfiles-$module allfiles-$module \
+            | uniq -u > missingfiles-$module
+        cat missingfiles-$module >> transferlist-$module
+
+        # Find dirs on the server which are missing on the client
+        sort localdirs-$module localdirs-$module alldirs-$module \
+            | uniq -u > missingdirs-$module
+        cat missingdirs-$module >> transferlist-$module
+
+        # Find files which have changed size
+        sort allfilesizes-$module localfilesizes-$module \
+            | uniq -u | awk -F '\t' '{print $1}' \
+            | uniq -d > updatedfiles-$module
+        cat updatedfiles-$module >> transferlist-$module
+
+        # Extract and verify checksums
+        awk -F '\t' "/^\[Checksums/ {s=1; next} /^$/ {s=0; next} {if (s) print \$1 \"  $moduledir/\" \$2}" $fl > checksums-$module
+        pushd $DESTD > /dev/null 2>&1
+        sha1sum --check --quiet $tempd/checksums-$module 2> /dev/null \
+            | grep -i 'failed$' \
+            | awk -F: '{print $1}' > $tempd/checksumfailed-$module
+        popd > /dev/null 2>&1
+        cat checksumfailed-$module >> transferlist-$module
+
+        # Count some things we want to use for stats later.
+        local cntlocalfiles=$(wc -l < localfiles-$module)
+        local cntlocaldirs=$(wc -l < localdirs-$module)
+
+        local cntextrafiles=$(wc -l < deletefiles-$module)
+        local cntextradirs=$(wc -l < deletedirs-$module)
+
+        local cntmissingfiles=$(wc -l < missingfiles-$module)
+        local cntmissingdirs=$(wc -l < missingdirs-$module)
+        totallines=$((totallines+cntmissingfiles+cntmissingdirs))
+
+        local cntsizechanged=$(wc -l < updatedfiles-$module)
+        totallines=$((totallines+cntsizechanged))
+
+        local cntupdatetimestamps=$(wc -l < updatetimestamps-$module)
+
+        local cntchecksumfailed=$(wc -l < checksumfailed-$module)
+        totallines=$((totallines+cntchecksumfailed))
+
+        db2f "Total on client:       %7d files, %4d dirs.\n" $cntlocalfiles $cntlocaldirs
+        db2f "Not present on server: %7d files, %4d dirs.\n" $cntextrafiles $cntextradirs
+        db2f "Missing on client:     %7d files, %4d dirs.\n" $cntmissingfiles $cntmissingdirs
+        db2f "Size Changed:          %7d files.\n" $cntsizechanged
+        db2f "Timestamps to restore: %7d files.\n" $cntupdatetimestamps
+        db2f "Checksum Failed:       %7d files.\n" $cntchecksumfailed
+    fi
+
+    sort -u transferlist-$module >> transferlist-sorted-$module
+    cat transferlist-sorted-$module >> master-transferlist
+    local cnttotaltransfer=$(wc -l < transferlist-sorted-$module)
+
+    logit P Processing end: $module
+    db2 Finished processing $module.
+
+    # Some basic info about the transfer.
+    db1 Changes in $module: $cnttotaltransfer files/dirs
+    if (( cnttotaltransfer <= 5 )); then
+        for i in $(cat transferlist-sorted-$module); do
+            db1 "    $i"
+        done
+    fi
+
+    # XXX We should clean some things up at this point, but we also need some
+    # files for the checkin later.
+    # Should be able to delete all *-$module, except for the dirlists, to give
+    # the current mirrormanager versions the things it needs.
+    #if (( VERBOSE <= 4 )); then
+    #    rm *-$module
+    #fi
+}
+
+
+# Main program execution
+# ======================
+parse_args "$@"
+set_default_vars
+read_config
+parse_args "$@" # So we can do overwrites
+# XXX check_dependencies
+
+# Paranoia; give us a few extra seconds.
+[[ -z $noparanoia ]] && starttime=$(($starttime-5))
+
+# Find the previous mirror time, and backdate if necessary
+LASTTIME=0
+if [[ -r $TIMEFILE ]]; then
+    source $TIMEFILE
+fi
+if [[ -n $backdate ]]; then
+    LASTTIME=$backdate
+fi
+
+# Make a temp dir and clean it up unless we're doing a lot of debugging
+if [[ -z $TMPDIR ]]; then
+    tempd=$(mktemp -d -t quick-mirror.XXXXXXXXXX)
+else
+    tempd=$(mktemp -d -p $TMPDIR -t quick-mirror.XXXXXXXXXX)
+fi
+
+if [[ $? -ne 0 ]]; then
+    (>&2 echo "Creating temporary directory failed?")
+    exit 1
+fi
+if (( VERBOSE <= 8 )); then
+    trap "rm -rf $tempd" EXIT
+fi
+
+# Set up a FIFO for logging.  Just calling systemd-cat repeatedly just gives us
+# a different PID every time, which is annoying.
+if [[ -n $LOGJOURNAL ]]; then
+    logfifo=$tempd/journal.fifo
+    mkfifo $logfifo
+    systemd-cat -t quick-fedora-mirror < $logfifo &
+    exec 3>$logfifo
+fi
+
+outfile=$tempd/output
+touch $outfile
+
+cd $tempd
+
+# At this point we can acquire the lock
+lock $TIMEFILE
+if (( ? != 0 )); then
+    db4 Could not acquire lock.
+    logit k lock contention
+    # Maybe we haven't been able to mirror for some time....
+    delay=$(( starttime - LASTTIME ))
+    if [[ -n $backdate || $LASTTIME -eq 0 ]]; then
+        delay=0
+    fi
+
+    if (( delay > WARNDELAY )); then
+        (>&2 echo No completed run since $(date -d @$LASTTIME ).)
+        logit E No completed run since $(date -d @$LASTTIME ).
+    fi
+    exit 1
+fi
+
+db1 "Mirror starting: $(date)"
+logit r Run start: cfg $cfgfile, tmp $tempd
+
+if (( VERBOSE >= 6 )); then
+    echo Times:
+    echo LASTTIME=$LASTTIME
+    echo starttime=$starttime
+    echo TIMEFILE=$TIMEFILE
+    echo Dirs:
+    echo tempd=$tempd
+    echo DESTD=$DESTD
+    echo Rsync:
+    echo REMOTE=$REMOTE
+    echo MASTERMODULE=$MASTERMODULE
+    echo RSYNC=$RSYNC
+    echo RSYNCOPTS=$RSYNCOPTS
+    echo Modules:
+    echo MODULES=$MODULES
+    echo MODULEMAPPING=$MODULEMAPPING
+    echo Misc:
+    echo VERBOSE=$VERBOSE
+fi
+
+(( VERBOSE >= 8 )) && set -x
+
+if [[ -n $MIRRORBUFFET ]]; then
+    # We want to mirror everything, so save the admin from listing the
+    # individual modules.
+    # ZSHISM (get keys from an associative array with (k))
+    MODULES=(${(k)MODULEMAPPING})
+    # BASHEQ MODULES=${!MODULEMAPPING[@]}
+    # bash3 equivalent is terrible
+fi
+
+fetch_file_lists
+
+logit p Processing start
+changed_modules=()
+for module in $MODULES; do
+    process_module $module
+done
+
+if [[ ! -e master-transferlist ]]; then
+    logit n No changes to synchronize
+    db2 No changed files.
+    finish no
+fi
+
+if [[ -n $MIRRORBUFFET ]]; then
+    echo DIRECTORY_SIZES.txt >> master-transferlist
+fi
+
+# The actual transfer
+# ===================
+sort -u master-transferlist > master-transferlist.sorted
+linecount=$(wc -l < master-transferlist.sorted)
+sep; sep
+db2 Transferring $linecount files.
+
+# Now we have a list of everything which has changed recently in every module
+# we want, pass that to rsync (non recursive mode!) and it should transfer just
+# the changed files without having to pull the entire huge file list.
+extra=()
+if [[ -n $rsyncdryrun ]]; then
+    extra+=(-n)
+fi
+do_rsync $REMOTE/$MASTERMODULE/ $DESTD master-transferlist.sorted extra
+rsyncreturn=$?
+if [[ $rsyncreturn -ne 0 ]]; then
+    (>&2 echo "rsync finished with nonzero exit status.\nWill not check in or delete anything.")
+    logit E skipping further operations due to rsync failure
+    finish
+fi
+
+# Total downloaded file count, bytes received, transfer speed
+logit s "stat: downloaded $rsfilestransferred files"
+logit s "stat: received $(hr_b $rstotalbytesreceived)"
+logit s "stat: transfer speed $(hr_b $rstransferspeed)/s"
+
+# Everything we can extract from rsync
+logit S "stat: sent $(hr_b $rstotalbytessent)"
+logit S "stat: speedup: $rsspeedup"
+logit S "stat: total size of transferred files: $(hr_b $rsfilesize)"
+logit S "stat: file list gen time $(hr_s $rsfilelistgentime)"
+logit S "stat: file list transfer time $(hr_s $rsfilelisttransfertime)"
+
+db1 "========================="
+db1 "Main transfer statistics:"
+db1 "    Downloaded files: $rsfilestransferred"
+db1 "    Total size of those files: $(hr_b $rsfilesize)"
+db1 "    Received: $(hr_b $rstotalbytesreceived)"
+db1 "    Sent: $(hr_b $rstotalbytessent)"
+db1 "    Speedup: $rsspeedup"
+db1 "    Trasfer speed: $(hr_b $rstransferspeed)/s"
+db1 "    File list generation time: $(hr_s $rsfilelistgentime)"
+db1 "    File list transfer time: $(hr_s $rsfilelisttransfertime)"
+
+# Local dir/file deletion
+# =======================
+if [[ -s master-deletedirs ]]; then
+    linecount=$(wc -l < master-deletedirs)
+
+    if [[ -n $skipdelete && $VERBOSE -ge 2 ]]; then
+        logit d Directory deletion skipped
+        echo "Not deleting  $linecount directories.  Delete list is:"
+        cat master-deletedirs
+        echo
+    else
+        logit d Directory deletion start: $linecount directories
+        db2 Removing $linecount stale directories.
+        for nuke in $(cat master-deletedirs); do
+            if [[ -d "$DESTD/$nuke" ]]; then
+                logit D Deleting directory $nuke
+                db4 Removing $nuke
+                rm -rf "$DESTD/$nuke"
+                deletedsomething=1
+            fi
+        done
+        logit d Directory deletion end
+    fi
+else
+    db2 No stale directories to delete.
+fi
+
+if [[ -s master-deletefiles ]]; then
+    linecount=$(wc -l < master-deletefiles)
+
+    if [[ -n $skipdelete ]]; then
+        logit d File deletion skipped
+        echo Not deleting $linecount stale files.  Delete list is:
+        cat master-deletefiles
+        echo
+    else
+        logit d File deletion begin: $linecount files
+        db2 Removing $linecount stale files.
+        # xopts=()
+        # (( VERBOSE >= 4 )) && xopts=(-t)
+        tr '\n' '\0' < master-deletefiles \
+            | (pushd $DESTD; xargs $xopts -0 rm -f ; popd)
+        # for nuke in $(cat master-deletefiles); do
+        #     logit D Deleting file $nuke
+        #     rm -f "$DESTD/$nuke"
+        # done
+        deletedsomething=1
+        logit d File deletion end
+    fi
+else
+    db2 No stale files to delete.
+fi
+
+if [[ -n $KEEPDIRTIMES && -s master-updatetimestamps ]]; then
+    extra=()
+    if [[ -n $rsyncdryrun ]]; then
+        extra+=(-n)
+    fi
+    logit d "Updating timestamps on $(wc -l < master-updatetimestamps) dirs"
+    do_rsync $REMOTE/$MASTERMODULE/ $DESTD master-updatetimestamps extra
+fi
+
+# State saving
+# XXX Doing the mv here actually undoes the locking.  Try to think of a better
+# way to do this.
+# ============
+if [[ -z $skiptimestamp ]]; then
+    db2 Saving mirror time to $TIMEFILE
+    if [[ -e $TIMEFILE ]]; then
+        mv $TIMEFILE $TIMEFILE.prev
+    fi
+    echo LASTTIME=$starttime > $TIMEFILE
+
+    if (( ? != 0 )); then
+        (>&2 echo Problem saving timestamp file $TIMEFILE)
+        exit 1
+    fi
+else
+    db2 Skipping timestamp save.
+fi
+
+# Mirrormanager Checkin and Callout
+# =================================
+# At this point we know that we had a clean run with no complaints from rsync,
+# and as far as we're concerned the run is now complete and recorded.
+#
+# So for each module we mirrored, the filtered file list is correct.  This
+# means that the alldirs-$module file is accurate and we can simply report its
+# contents to mirrormanager.
+if [[ -z $skipcheckin || -n $dumpmmcheckin ]]; then
+    db2 Performing mirrormanager checkin
+    logit m "mirrormanager checkin start"
+
+    # Check in just the changed modules
+    for module in $changed_modules; do
+        checkin_module $module
+    done
+
+    logit m "mirrormanager checkin end"
+fi
+finish


### PR DESCRIPTION
Things need attention:
1. I've slightly modified quick-fedora-mirror to make sure it can read some configuration from command line instead of its config, making universal config still viable. Its own config is still retained because it's still used to provide some can't-be-changing properties.
2. Need to add a Volume named /metadata to hold time file.
3. Modified quick-fedora-mirror is donated to public domain.
4. EPEL mirror is NO LONGER RECIEVING SYNC because it's covered in fedora-buffet. We may consider drop it.
5. I didn't add quick-fedora-hardlink because I heard we have more than plenty of disk space...

Please do review to prevent potential issues.